### PR TITLE
Update: テキスト入力欄の行頭の半角スペースを可視化した

### DIFF
--- a/src/components/functional/index.js
+++ b/src/components/functional/index.js
@@ -1,0 +1,2 @@
+export { visualizeHeadSpace } from 'components/functional/visualizeHeadSpace';
+export { invisibleHeadCup } from 'components/functional/invisibleHeadCup';

--- a/src/components/functional/invisibleHeadCup.js
+++ b/src/components/functional/invisibleHeadCup.js
@@ -1,0 +1,7 @@
+/**
+ * @param {string} text
+ * @return {string}
+ */
+
+export const invisibleHeadCup = (text) =>
+  text.replace(/^⊔+/, (match) => ' '.repeat(match.length));

--- a/src/components/functional/visualizeHeadSpace.js
+++ b/src/components/functional/visualizeHeadSpace.js
@@ -1,0 +1,7 @@
+/**
+ * @param {string} text
+ * @return {string}
+ */
+
+export const visualizeHeadSpace = (text) =>
+  text.replace(/^[ |⊔]+/, (match) => '⊔'.repeat(match.length));

--- a/src/components/model/codeSection/CodeField.jsx
+++ b/src/components/model/codeSection/CodeField.jsx
@@ -1,7 +1,8 @@
 import { css } from '@emotion/react';
 import { mq } from 'components/breakpoints';
+import { visualizeHeadSpace, invisibleHeadCup } from 'components/functional';
 
-export const CodeField = ({ name, mdText, setMdText }) => {
+export const CodeField = ({ name, active, mdText, setMdText }) => {
   const placeholder = `// Enter something like this.
 * problem
   * factor 1
@@ -64,8 +65,24 @@ export const CodeField = ({ name, mdText, setMdText }) => {
       </label>
       <textarea
         id="textarea"
-        onChange={(event) => setMdText(event.target.value)}
         placeholder={placeholder}
+        wrap="off"
+        // 改行毎の行頭の半角スペースを視認出来るように変換している
+        {...(!active && {
+          value: mdText
+            .split('\n')
+            .map((line) => visualizeHeadSpace(line))
+            .join('\n'),
+        })}
+        // 視覚化した半角スペースを元に戻してstateにセットする
+        onChange={(event) =>
+          setMdText(
+            event.target.value
+              .split('\n')
+              .map((line) => invisibleHeadCup(line))
+              .join('\n'),
+          )
+        }
         css={textareaStyle}
       />
     </div>
@@ -73,6 +90,7 @@ export const CodeField = ({ name, mdText, setMdText }) => {
 };
 
 const textareaStyle = (theme) => css`
+  font-family: MonoFont;
   box-sizing: border-box;
   font-size: 16px;
   color: ${theme.colors.white};

--- a/src/components/model/codeSection/index.jsx
+++ b/src/components/model/codeSection/index.jsx
@@ -2,17 +2,28 @@ import { SubTitle } from 'components/commons/title/SubTitle';
 import { CodeField } from './CodeField';
 import { css } from '@emotion/react';
 
-export const CodeSection = ({ mdText, setMdText, active, setActive, style }) => {
+export const CodeSection = ({
+  mdText,
+  setMdText,
+  active,
+  setActive,
+  style,
+}) => {
   return (
     <div
       onClick={() => setActive(false)}
-      className={active ? 'inactive' : 'active'}
+      className={active ? 'inactive' : 'active'} // ここのactiveは自身じゃなくてfilesがactiveかどうか
       css={css`
         ${style};
       `}
     >
       <SubTitle title="Input Text" />
-      <CodeField name="CODE" mdText={mdText} setMdText={setMdText} />
+      <CodeField
+        name="CODE"
+        mdText={mdText}
+        setMdText={setMdText}
+        active={active}
+      />
     </div>
   );
 };


### PR DESCRIPTION
# テキストエリアの半角スペースを可視化する

### 課題

<!-- 具体的に何をするのかを出来るだけ分かりやすく詳細に書く -->

- [x]  テキストエリアの半角スペースが見づらいので `␣` (U+2423) を表示するようにする
    
     → openboxというらしいが全角スペースぐらい取るので `⊔` スクエアカップを利用
    

変換する関数を作って、表示にだけ適用すればいい気がする

→ 表示に使う属性値は `value` だが、valueの値がstateにセットされるのでstateに渡す前に可視化する時と逆の処理が必要になった

### 補足

<!-- 課題に関する補足すべきことがあれば書く -->

### UI（スクリーンショット）

<!-- 見た目を変更が発生する場合のみ -->

### 懸念点

<!-- 作業における不安や内容の確認があれば書く -->

### 参考

属性値を条件分岐で出す方法: [https://hirakublog.com/react-props-attribute-name-branch/](https://hirakublog.com/react-props-attribute-name-branch/)

### 確認事項

<!-- 問題点は可能な限り対応して難しい場合は懸念点に記載する -->

- [x]  動作確認をしたか？
- [x]  新たにエラーは発生していないか？
- [x]  merge後に新たなTaskやIssueは発生するか？（発生する場合はTaskを作成したか？）

### 単体テストケース

<!— 単体テストケースのNotionリンクを貼り付ける —>