### PR TITLE
Feature/restore text

### DIFF
--- a/src/components/commons/button/DangerButton.jsx
+++ b/src/components/commons/button/DangerButton.jsx
@@ -1,16 +1,13 @@
-import { useNavigate } from 'react-router';
 import Button from '@mui/material/Button';
 
-export const DangerButton = ({ label, startIcon, endIcon, size }) => {
-  const navigate = useNavigate();
-
+export const DangerButton = ({ label, onClick, startIcon, endIcon, size }) => {
   return (
     <Button
       variant="contained"
       startIcon={startIcon}
       endIcon={endIcon}
       size={size}
-      onClick={() => navigate(`${process.env.PUBLIC_URL}`)}
+      onClick={onClick}
       sx={{
         color: 'text.main',
         width: '10rem',

--- a/src/components/page/convertResult/CancelButton.jsx
+++ b/src/components/page/convertResult/CancelButton.jsx
@@ -1,11 +1,17 @@
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { DangerButton } from 'components/commons/button/DangerButton';
+import { useNavigate } from 'react-router';
 
-export const CancelButton = () => {
+export const CancelButton = ({ mdText }) => {
+  const navigate = useNavigate();
+
   return (
     <DangerButton
-      label="CANCEL"
+      label="BACK"
       size="large"
+      onClick={() =>
+        navigate(`${process.env.PUBLIC_URL}`, { state: { mdText, active: false } })
+      }
       startIcon={<ArrowBackIcon />}
     />
   );

--- a/src/components/page/convertResult/index.jsx
+++ b/src/components/page/convertResult/index.jsx
@@ -44,7 +44,7 @@ export const ConvertResult = () => {
           justify-content: space-evenly;
         `}
       >
-        <CancelButton />
+        <CancelButton mdText={mdText} />
         <DownloadButton handler={download} />
         <div />
       </div>

--- a/src/components/page/home/Converter.jsx
+++ b/src/components/page/home/Converter.jsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { FileSection } from 'components/model/fileSection';
 import { CodeSection } from 'components/model/codeSection';
 import { ConvertButton } from './ConvertButton';
@@ -7,9 +7,12 @@ import { mq } from 'components/breakpoints';
 import { css } from '@emotion/react';
 
 export const Converter = () => {
-  const [mdText, setMdText] = useState('');
-  const [active, setActive] = useState(true);
   const navigate = useNavigate();
+  const location = useLocation();
+  // 変換後の画面からBACKボタンで戻ってきた時はデータを維持したまま表示する
+  const cachedText = location.state?.mdText ?? '';
+  const [mdText, setMdText] = useState(cachedText);
+  const [active, setActive] = useState(location.state?.active ?? true);
 
   const handleSubmit = (event) => {
     event.preventDefault();
@@ -26,6 +29,11 @@ export const Converter = () => {
       alert('入力されたデータは変換できません。');
     }
   };
+
+  // useLocationのstateをリフレッシュする
+  useEffect(() => {
+    return window.history.pushState(null, '');
+  });
 
   return (
     <div
@@ -47,6 +55,7 @@ export const Converter = () => {
         </div>
         <CodeSection
           mdText={mdText}
+          value={mdText}
           setMdText={setMdText}
           active={active}
           setActive={setActive}

--- a/src/components/page/home/Converter.jsx
+++ b/src/components/page/home/Converter.jsx
@@ -8,12 +8,12 @@ import { css } from '@emotion/react';
 
 export const Converter = () => {
   const navigate = useNavigate();
-  const location = useLocation();
   // 変換後の画面からBACKボタンで戻ってきた時はデータを維持したまま表示する
-  const cachedText = location.state?.mdText ?? '';
+  const location = useLocation();
+  const cachedState = location.state;
+  const cachedText = cachedState?.mdText ?? '';
   const [mdText, setMdText] = useState(cachedText);
-  const [active, setActive] = useState(location.state?.active ?? true);
-
+  const [active, setActive] = useState(cachedState?.active ?? true);
   const handleSubmit = (event) => {
     event.preventDefault();
     const mdLines = mdText.split('\n');


### PR DESCRIPTION
# textareaの入力値をブラウザバックした時に回復させる

### 課題

<!-- 具体的に何をするのかを出来るだけ分かりやすく詳細に書く -->

- [x]  **codeSectionに入力した値**はブラウザバックした時に復元するようにする。
    
    → ファイルのアップロードの場合でもテキストとして復元するようにした
    
    → ブラウザバック, TOPへの遷移, リロードでは復元せず、描写後にBACKを押した時のみ復元させるようにした
    

### 補足

<!-- 課題に関する補足すべきことがあれば書く -->

### UI（スクリーンショット）

<!-- 見た目を変更が発生する場合のみ -->

### 懸念点

<!-- 作業における不安や内容の確認があれば書く -->

**実装の方向性**

codeSectionのvalueをglobal なstateにして、そのstateの値を表示する

**なぜそうするのか**

1. 変換後、間違えて戻った時とかに書き直すのは嫌
2. localhostやクエリに乗せることも考えたが、**textareaのvalueだけ**をstateで管理するのがスマートだと考える。
3. stateを使うのでタブを再読み込みすると消えるがそれは構わぬ  ← 少なくともuseLocationでsetしたstateは再読み込みしても消えなかったので認識に違いがあるかも。

### 確認事項

<!-- 問題点は可能な限り対応して難しい場合は懸念点に記載する -->

- [x]  動作確認をしたか？
- [x]  新たにエラーは発生していないか？
- [x]  merge後に新たなTaskやIssueは発生するか？（発生する場合はTaskを作成したか？）

### 単体テストケース

<!— 単体テストケースのNotionリンクを貼り付ける —>